### PR TITLE
frequency_counter example missing include

### DIFF
--- a/devices/buffered_display.h
+++ b/devices/buffered_display.h
@@ -26,6 +26,8 @@
 #ifndef AVRLIB_DEVICES_BUFFERED_DISPLAY_H_
 #define AVRLIB_DEVICES_BUFFERED_DISPLAY_H_
 
+#include <string.h>
+
 #include "avrlib/base.h"
 #include "avrlib/log2.h"
 #include "avrlib/op.h"


### PR DESCRIPTION
With this fix applied, avril-examples/frequency_counter builds cleanly.
