### PR TITLE
Atmega2560 basics

### DIFF
--- a/boot.h
+++ b/boot.h
@@ -47,6 +47,14 @@ inline void Boot(bool init_timers) {
 #ifdef HAS_USART1
   UCSR1B = 0;
 #endif
+
+#ifdef HAS_USART2
+  UCSR2B = 0;
+#endif
+
+#ifdef HAS_USART3
+  UCSR3B = 0
+#endif
 }
 
 }  // avr

--- a/gpio.h
+++ b/gpio.h
@@ -79,6 +79,40 @@ typedef Port<PINARegister, PORTARegister, DDRARegister> PortA;
 
 #endif
 
+#if defined (ATMEGA640) || defined (ATMEGA1280) || defined(ATMEGA2560)
+IORegister(DDRE);
+IORegister(DDRF);
+IORegister(DDRG);
+IORegister(DDRH);
+IORegister(DDRJ);
+IORegister(DDRK);
+IORegister(DDRL);
+
+IORegister(PORTE);
+IORegister(PORTF);
+IORegister(PORTG);
+IORegister(PORTH);
+IORegister(PORTJ);
+IORegister(PORTK);
+IORegister(PORTL);
+
+IORegister(PINE);
+IORegister(PINF);
+IORegister(PING);
+IORegister(PINH);
+IORegister(PINJ);
+IORegister(PINK);
+IORegister(PINL);
+
+typedef Port<PINERegister, PORTERegister, DDRERegister> PortE;
+typedef Port<PINFRegister, PORTFRegister, DDRFRegister> PortF;
+typedef Port<PINGRegister, PORTGRegister, DDRGRegister> PortG;
+typedef Port<PINHRegister, PORTHRegister, DDRHRegister> PortH;
+typedef Port<PINJRegister, PORTJRegister, DDRJRegister> PortJ;
+typedef Port<PINKRegister, PORTKRegister, DDRKRegister> PortK;
+typedef Port<PINLRegister, PORTLRegister, DDRLRegister> PortL;
+
+#endif
 
 
 // The actual implementation of a pin, not very convenient to use because it
@@ -293,9 +327,74 @@ typedef Gpio<PortD, 2> UartSpi1RX;
 #define HAS_USART0
 #define HAS_USART1
 
-#ifdef ATMEGA1284P
+#if defined(ATMEGA1284P) || defined(ATMEGA640) || defined(ATMEGA1280)  \
+	|| defined(ATMEGA2560)
 #define HAS_TIMER3
 #endif
+
+#elif defined (ATMEGA640) || defined(ATMEGA1280) || defined(ATMEGA2560)
+
+SetupGpio(0,  PortB, NoPwmChannel, 0);
+SetupGpio(1,  PortB, NoPwmChannel, 1);
+SetupGpio(2,  PortB, NoPwmChannel, 2);
+SetupGpio(3,  PortB, NoPwmChannel, 3);
+SetupGpio(4,  PortB, PwmChannel2A, 4);
+SetupGpio(5,  PortB, PwmChannel1A, 5);
+SetupGpio(6,  PortB, PwmChannel1B, 6);
+SetupGpio(7,  PortB, PwmChannel0A, 7);
+
+SetupGpio(8,  PortD, NoPwmChannel, 0);
+SetupGpio(9,  PortD, NoPwmChannel, 1);
+SetupGpio(10, PortD, NoPwmChannel, 2);
+SetupGpio(11, PortD, NoPwmChannel, 3);
+SetupGpio(12, PortD, NoPwmChannel, 4);
+SetupGpio(13, PortD, NoPwmChannel, 5);
+SetupGpio(14, PortD, NoPwmChannel, 6);
+SetupGpio(15, PortD, NoPwmChannel, 7);
+
+SetupGpio(16, PortC, NoPwmChannel, 0);
+SetupGpio(17, PortC, NoPwmChannel, 1);
+SetupGpio(18, PortC, NoPwmChannel, 2);
+SetupGpio(19, PortC, NoPwmChannel, 3);
+SetupGpio(20, PortC, NoPwmChannel, 4);
+SetupGpio(21, PortC, NoPwmChannel, 5);
+SetupGpio(22, PortC, NoPwmChannel, 6);
+SetupGpio(23, PortC, NoPwmChannel, 7);
+
+SetupGpio(24, PortE, NoPwmChannel, 0);
+SetupGpio(25, PortE, NoPwmChannel, 1);
+SetupGpio(26, PortE, NoPwmChannel, 2);
+SetupGpio(27, PortE, NoPwmChannel, 3);
+SetupGpio(28, PortE, NoPwmChannel, 4);
+SetupGpio(29, PortE, NoPwmChannel, 5);
+SetupGpio(30, PortE, NoPwmChannel, 6);
+SetupGpio(31, PortE, NoPwmChannel, 7);
+
+typedef Gpio<PortB, 0> SpiSS;
+typedef Gpio<PortB, 1> SpiSCK;
+typedef Gpio<PortB, 2> SpiMOSI;
+typedef Gpio<PortB, 3> SpiMISO;
+
+typedef Gpio<PortE, 2> UartSpi0XCK;
+typedef Gpio<PortE, 1> UartSpi0TX;
+typedef Gpio<PortE, 0> UartSpi0RX;
+
+typedef Gpio<PortD, 5> UartSpi1XCK;
+typedef Gpio<PortD, 3> UartSpi1TX;
+typedef Gpio<PortD, 2> UartSpi1RX;
+
+typedef Gpio<PortH, 2> UartSpi2XCK;
+typedef Gpio<PortH, 1> UartSpi2TX;
+typedef Gpio<PortH, 0> UartSpi2RX;
+
+typedef Gpio<PortJ, 2> UartSpi3XCK;
+typedef Gpio<PortJ, 1> UartSpi3TX;
+typedef Gpio<PortJ, 0> UartSpi3RX;
+
+#define HAS_USART0
+#define HAS_USART1
+#define HAS_USART2
+#define HAS_USART3
 
 #else
 

--- a/makefile.mk
+++ b/makefile.mk
@@ -13,10 +13,13 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-AVRLIB_TOOLS_PATH = /opt/local/bin/
+AVRLIB_TOOLS_PATH ?= /usr/local/CrossPack-AVR/bin/
 BUILD_ROOT     = build/
 BUILD_DIR      = $(BUILD_ROOT)$(TARGET)/
-PROGRAMMER     = avrispmkII
+PROGRAMMER     ?= avrispmkII
+PROGRAMMER_PORT ?= usb
+AVRDUDE_ERASE  ?= no
+AVRDUDE_LOCK   ?= yes
 
 ifeq ($(FAMILY),tiny)
 MCU            = attiny$(MCU_NAME)
@@ -27,6 +30,11 @@ ifeq ($(MCU_NAME),atmega2560)
 MCU=atmega2560
 DMCU=atmega2560
 MCU_DEFINE=ATMEGA2560
+else
+ifeq ($(FAMILY),mega)
+MCU            = atmega$(MCU_NAME)
+DMCU           = atmega$(MCU_NAME)
+MCU_DEFINE     = ATMEGA$(MCU_NAME)
 else
 MCU            = atmega$(MCU_NAME)p
 DMCU           = m$(MCU_NAME)p
@@ -126,8 +134,19 @@ $(BUILD_DIR)%.sym: $(BUILD_DIR)%.elf
 # ------------------------------------------------------------------------------
 
 AVRDUDE_COM_OPTS = -V -p $(DMCU)
-AVRDUDE_ISP_OPTS = -c $(PROGRAMMER) -P usb
+AVRDUDE_ISP_OPTS = -c $(PROGRAMMER) -P $(PROGRAMMER_PORT)
 
+ifeq ($(AVRDUDE_LOCK),no)
+AVRDUDE_LOCK_OPTS =
+else
+AVRDUDE_LOCK_OPTS ?= -U lock:w:0x$(LOCK):m
+endif
+
+ifeq ($(AVRDUDE_ERASE),no)
+AVRDUDE_ERASE_OPTS = 
+else
+AVRDUDE_ERASE_OPTS ?= -D
+endif
 # ------------------------------------------------------------------------------
 # Main targets
 # ------------------------------------------------------------------------------
@@ -145,13 +164,14 @@ $(DEP_FILE):  $(BUILD_DIR) $(DEPS)
 
 bin:	$(TARGET_BIN)
 
+
 upload:    $(TARGET_HEX)
-		$(AVRDUDE) $(AVRDUDE_COM_OPTS) $(AVRDUDE_ISP_OPTS) \
-			-B 1 -U flash:w:$(TARGET_HEX):i -U lock:w:0x$(LOCK):m
+		$(AVRDUDE) $(AVRDUDE_ERASE_OPTS) $(AVRDUDE_COM_OPTS) $(AVRDUDE_ISP_OPTS) \
+			-B 1 -U flash:w:$(TARGET_HEX):i $(AVRDUDE_LOCK_OPTS) 
 
 slow_upload:    $(TARGET_HEX)
-		$(AVRDUDE) $(AVRDUDE_COM_OPTS) $(AVRDUDE_ISP_OPTS) \
-			-B 4 -U flash:w:$(TARGET_HEX):i -U lock:w:0x$(LOCK):m
+		$(AVRDUDE) $(AVRDUDE_ERASE_OPTS) $(AVRDUDE_COM_OPTS) $(AVRDUDE_ISP_OPTS) \
+			-B 4 -U flash:w:$(TARGET_HEX):i $(AVRDUDE_LOCK_OPTS)
 
 clean:
 		$(REMOVE) $(OBJS) $(TARGETS) $(DEP_FILE) $(DEPS)

--- a/serial.h
+++ b/serial.h
@@ -300,6 +300,58 @@ typedef SerialPort<
 
 #endif  // #ifdef HAS_USART1
 
+
+#ifdef HAS_USART2
+
+IORegister(UBRR2H);
+IORegister(UBRR2L);
+IORegister16(UBRR2);
+IORegister(UCSR2A);
+IORegister(UCSR2B);
+IORegister(UCSR2C);
+IORegister(UDR2);
+
+typedef SerialPort<
+    BitInRegister<UCSR2BRegister, TXEN2>,
+    BitInRegister<UCSR2ARegister, UDRE2>,
+    BitInRegister<UCSR2BRegister, RXEN2>,
+    BitInRegister<UCSR2ARegister, RXC2>,
+    BitInRegister<UCSR2BRegister, RXCIE2>,
+    BitInRegister<UCSR2ARegister, U2X2>,
+    UBRR2HRegister,
+    UBRR2LRegister,
+    UDR2Register,
+    kSerialOutputBufferSize,
+    kSerialInputBufferSize> SerialPort2;
+
+#endif  // #ifdef HAS_USART2
+
+#ifdef HAS_USART3
+
+IORegister(UBRR3H);
+IORegister(UBRR3L);
+IORegister16(UBRR3);
+IORegister(UCSR3A);
+IORegister(UCSR3B);
+IORegister(UCSR3C);
+IORegister(UDR3);
+
+typedef SerialPort<
+    BitInRegister<UCSR3BRegister, TXEN3>,
+    BitInRegister<UCSR3ARegister, UDRE3>,
+    BitInRegister<UCSR3BRegister, RXEN3>,
+    BitInRegister<UCSR3ARegister, RXC3>,
+    BitInRegister<UCSR3BRegister, RXCIE3>,
+    BitInRegister<UCSR3ARegister, U2X3>,
+    UBRR3HRegister,
+    UBRR3LRegister,
+    UDR3Register,
+    kSerialOutputBufferSize,
+    kSerialInputBufferSize> SerialPort3;
+
+#endif  // #ifdef HAS_USART3
+
 }  // namespace avrlib
+
 
 #endif  // AVRLIB_SERIAL_H_


### PR DESCRIPTION
Struggling a bit with git, but I think this is right now
- add remaining ATmega640/1280/2560 GPIO Ports E-L
- add ATmega640/1280/2560 Serial2 and Serial3
- some makefile hackery to eliminate the need to edit the makefile in many cases

Missing: ATmega640/1280/2560 additional PWM pin definitions for GPIO Ports E-L
